### PR TITLE
Add support to create a client for a grafana datasource

### DIFF
--- a/smapi.go
+++ b/smapi.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/grafana/synthetic-monitoring-api-go-client/model"
 
@@ -56,6 +57,29 @@ func NewClient(baseURL, accessToken string, client *http.Client) *Client {
 	}
 
 	u.Path = path.Clean(u.Path)
+
+	return &Client{
+		client:      client,
+		accessToken: accessToken,
+		baseURL:     u.String(),
+	}
+}
+
+// NewDatasourceClient creates a new client for the Synthetic Monitoring API using a Grafana datasource proxy.
+//
+// The accessToken should be the grafana access token.
+//
+// If no client is provided, http.DefaultClient will be used.
+func NewDatasourceClient(baseURL, accessToken string, client *http.Client) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/")
 
 	return &Client{
 		client:      client,

--- a/smapi_test.go
+++ b/smapi_test.go
@@ -244,6 +244,47 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewDatasourceClient(t *testing.T) {
+	url, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	testcases := map[string]struct {
+		url         string
+		accessToken string
+		client      *http.Client
+	}{
+		"trivial": {
+			url: url,
+		},
+		"extra slash": {
+			url: url + "/",
+		},
+		"access token": {
+			url:         url,
+			accessToken: "123",
+		},
+		"default http client": {
+			url:    url,
+			client: http.DefaultClient,
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			c := NewDatasourceClient(testcase.url, testcase.accessToken, testcase.client)
+
+			require.NotNil(t, c)
+			require.NotNil(t, c.client)
+			if testcase.client != nil {
+				require.Equal(t, testcase.client, c.client)
+			}
+			require.Equal(t, c.accessToken, testcase.accessToken)
+			require.Equal(t, c.baseURL, url)
+		})
+	}
+}
+
 // TestClientDo tests the "do" method of the API client in order to make
 // sure that it does handle errors correctly.
 func TestClientDo(t *testing.T) {


### PR DESCRIPTION
Currently, the base URL is systematically suffixed by `/api/v1`. In case
of using Grafana Cloud, the base URL looks like
https://${grafanacloudstack}.grafana.net/api/datasources/proxy/${datasourceID}/sm/

Adding support to create a plain client specifying the grafana proxy URL
allows to simplify the client initialization inspecting all Grafana
Datasources using an initialized grafana go client.