### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v0.9.0"></a>
+## [v0.9.0] - 2024-11-13
+### Fix
+- update grafana-build-tools to v0.32.0
+
+
 <a name="v0.8.0"></a>
 ## [v0.8.0] - 2024-01-31
 
@@ -80,7 +86,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2021-06-22
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.9.0...HEAD
+[v0.9.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.6.5...v0.7.0
 [v0.6.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.6.4...v0.6.5


### PR DESCRIPTION
* Fix: update grafana-build-tools to v0.32.0
* Bump github.com/grafana/synthetic-monitoring-agent from 0.28.2 to 0.29.1
* Bump github.com/grafana/synthetic-monitoring-agent from 0.28.1 to 0.28.2
* Bump github.com/urfave/cli/v2 from 2.27.4 to 2.27.5
* Bump github.com/grafana/synthetic-monitoring-agent from 0.28.0 to 0.28.1 (#212)
* Bump github.com/grafana/synthetic-monitoring-agent from 0.27.0 to 0.28.0 (#211)
* Bump github.com/grafana/synthetic-monitoring-agent from 0.26.0 to 0.27.0 (#210)
* Bump github.com/urfave/cli/v2 from 2.27.3 to 2.27.4
* Bump github.com/grafana/synthetic-monitoring-agent from 0.25.2 to 0.26.0
* Bump github.com/grafana/synthetic-monitoring-agent from 0.25.0 to 0.25.2
* Bump github.com/urfave/cli/v2 from 2.27.2 to 2.27.3
* Bump github.com/grafana/synthetic-monitoring-agent from 0.24.3 to 0.25.0
* Convert to Github Actions Just a quick drive-by. Public repos are easy to migrate :)
* Bump github.com/grafana/synthetic-monitoring-agent from 0.23.4 to 0.24.3 (#203)
* Bump github.com/rs/zerolog from 1.32.0 to 1.33.0 (#200)
* update timeout and frequency limits in API (#197)
* Bump github.com/urfave/cli/v2 from 2.27.1 to 2.27.2 (#196)
* Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in /scripts/go
* Bump github.com/grafana/synthetic-monitoring-agent from 0.22.0 to 0.23.4
* Bump github.com/grafana/synthetic-monitoring-agent from 0.21.0 to 0.22.0
* Upgrade to grafana-build-tools v0.6.1
* Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#187)
* Bump github.com/grafana/synthetic-monitoring-agent from 0.20.1 to 0.21.0
* Bump github.com/grafana/synthetic-monitoring-agent from 0.19.4 to 0.20.1