### PR TITLE
fix: release-please config missing extra-files

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -10,7 +10,8 @@
         { "type": "fix", "section": "Fixes" },
         { "type": "docs", "section": "Documentation" },
         { "type": "chore", "section": "Miscellaneous Chores" }
-      ]
+      ],
+      "extra-files": ["version/version.go"]
     }
   },
   "draft-pull-request": true,


### PR DESCRIPTION
For the generic updater to pick up and apply the `x-release-please-version` comment, version.go is now included in the release-please package config via the `extra-files` option.

Follows https://github.com/grafana/synthetic-monitoring-api-go-client/pull/318 which fixed the extra changelog issue but dropped the update for the `version` const.

This should now keep the const in `version.go` updated as part of the main release without making release-please track a separate package (and changelog) for it.