### PR TITLE
Add support for the secret manager in http checks

### DIFF
--- a/cli/check.go
+++ b/cli/check.go
@@ -169,6 +169,10 @@ func GetCheckCommands(cc ChecksClient) cli.Commands {
 							Name:  "cache-busting-parameter-name",
 							Usage: "name of the query parameter to add to the request to bust the cache",
 						},
+						&cli.BoolFlag{
+							Name:  "secret-manager-enabled",
+							Usage: "enable secret manager for bearer token and basic auth password resolution",
+						},
 					},
 				},
 				{
@@ -454,6 +458,7 @@ func (c ChecksClient) checkAddHttp(ctx *cli.Context) error {
 				Body:                       ctx.String("body"),
 				NoFollowRedirects:          ctx.Bool("no-follow-redirects"),
 				BearerToken:                ctx.String("bearer-token"),
+				SecretManagerEnabled:       ctx.Bool("secret-manager-enabled"),
 				FailIfSSL:                  ctx.Bool("fail-if-ssl"),
 				FailIfNotSSL:               ctx.Bool("fail-if-not-ssl"),
 				ValidStatusCodes:           validHttpStatusCodes,

--- a/docs/API.md
+++ b/docs/API.md
@@ -307,6 +307,7 @@ For HTTP, the structure is as follows:
     "password": <string>
   },
   "bearerToken": <string>,
+  "secretManagerEnabled": <boolean>,
   "proxyURL": <string>,
   "failIfSSL": <boolean>,
   "failIfNotSSL": <boolean>,

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,9 @@ github.com/grafana/synthetic-monitoring-agent v0.41.2 h1:deQjMBZtsUZloDCcEWLNp5/
 github.com/grafana/synthetic-monitoring-agent v0.41.2/go.mod h1:YDRa8lcBC6ZWntXqGeev+iDmbc7o1cZvVyJCOG6IR0c=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Following https://github.com/grafana/synthetic-monitoring-agent/pull/1415 this exposes the boolean in the api client.