### PR TITLE
fix: change runbookUrl casing to what the API expects

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -89,7 +89,7 @@ type CheckAlert struct {
 	Name       string  `json:"name"`
 	Threshold  float64 `json:"threshold"`
 	Period     string  `json:"period,omitempty"`
-	RunbookUrl string  `json:"runbook_url,omitempty"`
+	RunbookUrl string  `json:"runbookUrl,omitempty"`
 	Created    int64   `json:"created"`
 	Modified   int64   `json:"modified"`
 }


### PR DESCRIPTION
## Fix runbook_url field to match API specification

Corrects the JSON field name for `runbook_url` in `CheckAlert` struct from snake_case (`runbook_url`) to camelCase (`runbookUrl`) to match the API specification. This ensures runbook URLs are properly serialized and recognized by the server.