### PR TITLE
feat: Implement /check/query endpoint as QueryCheck

### DIFF
--- a/smapi.go
+++ b/smapi.go
@@ -505,6 +505,26 @@ func (h *Client) ListChecks(ctx context.Context) ([]synthetic_monitoring.Check, 
 	return result, nil
 }
 
+// QueryCheck returns a Synthetic Monitoring check for the
+// authenticated tenant that matches the job and target passed in.
+func (h *Client) QueryCheck(ctx context.Context, job string, target string) (*synthetic_monitoring.Check, error) {
+	if err := h.requireAuthToken(); err != nil {
+		return nil, err
+	}
+
+	resp, err := h.Get(ctx, fmt.Sprintf("/check/query?job=%s&target=%s", job, target), true, nil)
+	if err != nil {
+		return nil, fmt.Errorf("check query err: %w", err)
+	}
+
+	var result *synthetic_monitoring.Check
+
+	if err := ValidateResponse("check query request", resp, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // GetTenant retrieves the information associated with the authenticated
 // tenant.
 func (h *Client) GetTenant(ctx context.Context) (*synthetic_monitoring.Tenant, error) {


### PR DESCRIPTION
Adds a new method `QueryCheck` that is a wrapper for the [/check/query](https://synthetic-monitoring-api-dev.grafana-dev.net/api/v1/swagger#/operations/GET_/api/v1/check/query) api end point. It accepts a job and a target which gets added as query parameters to the url. QueryCheck returns a single check that gets matched.

Implements a basic set of tests that emulates the api end filtering checks by job and target. Ensures that it handles the case where no checks are matched.