### PR TITLE
feat: Add folderUid support 

### DIFF
--- a/cli/check.go
+++ b/cli/check.go
@@ -11,6 +11,7 @@ import (
 
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
+	"github.com/grafana/synthetic-monitoring-api-go-client/model"
 	"github.com/urfave/cli/v2"
 )
 
@@ -433,7 +434,6 @@ func (c ChecksClient) checkAddPing(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
-		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Ping: &sm.PingSettings{
 				IpVersion:    ipVersion,
@@ -467,7 +467,7 @@ func (c ChecksClient) checkAddPing(ctx *cli.Context) error {
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	newCheck, err := smClient.AddCheck(ctx.Context, check)
+	newCheck, err := smClient.AddCheck(ctx.Context, model.Check{Check: check, FolderUid: ctx.String("folder-uid")})
 	if err != nil {
 		return fmt.Errorf("adding check: %w", err)
 	}
@@ -512,7 +512,6 @@ func (c ChecksClient) checkAddHttp(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
-		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Http: &sm.HttpSettings{
 				IpVersion:                  ipVersion,
@@ -560,7 +559,7 @@ func (c ChecksClient) checkAddHttp(ctx *cli.Context) error {
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	newCheck, err := smClient.AddCheck(ctx.Context, check)
+	newCheck, err := smClient.AddCheck(ctx.Context, model.Check{Check: check, FolderUid: ctx.String("folder-uid")})
 	if err != nil {
 		return fmt.Errorf("adding check: %w", err)
 	}
@@ -589,7 +588,6 @@ func (c ChecksClient) checkAddDns(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
-		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Dns: &sm.DnsSettings{
 				IpVersion:   ipVersion,
@@ -634,7 +632,7 @@ func (c ChecksClient) checkAddDns(ctx *cli.Context) error {
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	newCheck, err := smClient.AddCheck(ctx.Context, check)
+	newCheck, err := smClient.AddCheck(ctx.Context, model.Check{Check: check, FolderUid: ctx.String("folder-uid")})
 	if err != nil {
 		return fmt.Errorf("adding check: %w", err)
 	}
@@ -663,7 +661,6 @@ func (c ChecksClient) checkAddTcp(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
-		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Tcp: &sm.TcpSettings{
 				IpVersion: ipVersion,
@@ -709,7 +706,7 @@ func (c ChecksClient) checkAddTcp(ctx *cli.Context) error {
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	newCheck, err := smClient.AddCheck(ctx.Context, check)
+	newCheck, err := smClient.AddCheck(ctx.Context, model.Check{Check: check, FolderUid: ctx.String("folder-uid")})
 	if err != nil {
 		return fmt.Errorf("adding check: %w", err)
 	}
@@ -746,7 +743,7 @@ func (c ChecksClient) checkDelete(ctx *cli.Context) error {
 	return nil
 }
 
-func (c ChecksClient) showCheck(ctx *cli.Context, output io.Writer, check *sm.Check) error {
+func (c ChecksClient) showCheck(ctx *cli.Context, output io.Writer, check *model.Check) error {
 	w := c.TabWriterBuilder(ctx)
 	fmt.Fprintf(w, "%s:\t%d\n", "id", check.Id)
 	fmt.Fprintf(w, "%s:\t%s\n", "type", check.Type())

--- a/cli/check.go
+++ b/cli/check.go
@@ -49,6 +49,10 @@ func getCommonCheckFlags() []cli.Flag {
 			Usage: "names or IDs of the probes where this check should run",
 			Value: cli.NewStringSlice("all"),
 		},
+		&cli.StringFlag{
+			Name:  "folder-uid",
+			Usage: "UID of the Grafana folder to associate with the check",
+		},
 	}
 }
 
@@ -429,6 +433,7 @@ func (c ChecksClient) checkAddPing(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
+		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Ping: &sm.PingSettings{
 				IpVersion:    ipVersion,
@@ -507,6 +512,7 @@ func (c ChecksClient) checkAddHttp(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
+		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Http: &sm.HttpSettings{
 				IpVersion:                  ipVersion,
@@ -583,6 +589,7 @@ func (c ChecksClient) checkAddDns(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
+		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Dns: &sm.DnsSettings{
 				IpVersion:   ipVersion,
@@ -656,6 +663,7 @@ func (c ChecksClient) checkAddTcp(ctx *cli.Context) error {
 		Frequency: ctx.Duration("frequency").Milliseconds(),
 		Timeout:   ctx.Duration("timeout").Milliseconds(),
 		Enabled:   ctx.Bool("enabled"),
+		FolderUid: ctx.String("folder-uid"),
 		Settings: sm.CheckSettings{
 			Tcp: &sm.TcpSettings{
 				IpVersion: ipVersion,
@@ -747,6 +755,7 @@ func (c ChecksClient) showCheck(ctx *cli.Context, output io.Writer, check *sm.Ch
 	fmt.Fprintf(w, "%s:\t%t\n", "enabled", check.Enabled)
 	fmt.Fprintf(w, "%s:\t%s\n", "frequency", time.Duration(check.Frequency)*time.Millisecond)
 	fmt.Fprintf(w, "%s:\t%s\n", "timeout", time.Duration(check.Timeout)*time.Millisecond)
+	fmt.Fprintf(w, "%s:\t%s\n", "folder-uid", check.FolderUid)
 	fmt.Fprintf(w, "%s:\t%s\n", "created", formatSMTime(check.Created))
 	fmt.Fprintf(w, "%s:\t%s\n", "modified", formatSMTime(check.Modified))
 

--- a/examples/add-checks/main.go
+++ b/examples/add-checks/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
+	"github.com/grafana/synthetic-monitoring-api-go-client/model"
 	"github.com/rs/zerolog"
 )
 
@@ -161,7 +162,7 @@ func addChecks(ctx context.Context, client *smapi.Client, logger zerolog.Logger)
 	}
 
 	for _, check := range getTestChecks(1, probeIDs) {
-		c, err := client.AddCheck(ctx, check)
+		c, err := client.AddCheck(ctx, model.Check{Check: check})
 		if err != nil {
 			logger.Error().Err(err).Msg("adding check")
 			continue

--- a/model/model.go
+++ b/model/model.go
@@ -100,8 +100,15 @@ type CheckAlertWithStatus struct {
 	Error  string `json:"error,omitempty"`
 }
 
-type CheckWithAlerts struct {
+// Check wraps the protobuf Check type and adds API-only fields that are not
+// part of the protobuf definition.
+type Check struct {
 	synthetic_monitoring.Check
+	FolderUid string `json:"folderUid,omitempty"`
+}
+
+type CheckWithAlerts struct {
+	Check
 	Alerts []CheckAlertWithStatus `json:"alerts"`
 }
 

--- a/smapi.go
+++ b/smapi.go
@@ -400,7 +400,7 @@ func (h *Client) ListProbes(ctx context.Context) ([]synthetic_monitoring.Probe, 
 // AddCheck creates a new Synthetic Monitoring check in the API server.
 //
 // The return value contains the assigned ID.
-func (h *Client) AddCheck(ctx context.Context, check synthetic_monitoring.Check) (*synthetic_monitoring.Check, error) {
+func (h *Client) AddCheck(ctx context.Context, check model.Check) (*model.Check, error) {
 	if err := h.requireAuthToken(); err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (h *Client) AddCheck(ctx context.Context, check synthetic_monitoring.Check)
 		return nil, fmt.Errorf("sending check add request: %w", err)
 	}
 
-	var result synthetic_monitoring.Check
+	var result model.Check
 
 	if err := ValidateResponse("check add request", resp, &result); err != nil {
 		return nil, err
@@ -421,7 +421,7 @@ func (h *Client) AddCheck(ctx context.Context, check synthetic_monitoring.Check)
 
 // GetCheck returns a single Synthetic Monitoring check identified by
 // the provided ID.
-func (h *Client) GetCheck(ctx context.Context, id int64) (*synthetic_monitoring.Check, error) {
+func (h *Client) GetCheck(ctx context.Context, id int64) (*model.Check, error) {
 	if err := h.requireAuthToken(); err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (h *Client) GetCheck(ctx context.Context, id int64) (*synthetic_monitoring.
 		return nil, fmt.Errorf("sending check get request: %w", err)
 	}
 
-	var result synthetic_monitoring.Check
+	var result model.Check
 
 	if err := ValidateResponse("check get request", resp, &result); err != nil {
 		return nil, err
@@ -444,7 +444,7 @@ func (h *Client) GetCheck(ctx context.Context, id int64) (*synthetic_monitoring.
 //
 // The return value contains the updated check (updated timestamps,
 // etc).
-func (h *Client) UpdateCheck(ctx context.Context, check synthetic_monitoring.Check) (*synthetic_monitoring.Check, error) {
+func (h *Client) UpdateCheck(ctx context.Context, check model.Check) (*model.Check, error) {
 	if err := h.requireAuthToken(); err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func (h *Client) UpdateCheck(ctx context.Context, check synthetic_monitoring.Che
 		return nil, fmt.Errorf("sending check update request: %w", err)
 	}
 
-	var result synthetic_monitoring.Check
+	var result model.Check
 
 	if err := ValidateResponse("check update request", resp, &result); err != nil {
 		return nil, err
@@ -486,7 +486,7 @@ func (h *Client) DeleteCheck(ctx context.Context, id int64) error {
 
 // ListChecks returns the list of Synthetic Monitoring checks for the
 // authenticated tenant.
-func (h *Client) ListChecks(ctx context.Context) ([]synthetic_monitoring.Check, error) {
+func (h *Client) ListChecks(ctx context.Context) ([]model.Check, error) {
 	if err := h.requireAuthToken(); err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (h *Client) ListChecks(ctx context.Context) ([]synthetic_monitoring.Check, 
 		return nil, fmt.Errorf("sending check list request: %w", err)
 	}
 
-	var result []synthetic_monitoring.Check
+	var result []model.Check
 
 	if err := ValidateResponse("check list request", resp, &result); err != nil {
 		return nil, err
@@ -529,7 +529,7 @@ func (h *Client) ListChecksWithAlerts(ctx context.Context) ([]model.CheckWithAle
 // QueryCheck returns a Synthetic Monitoring check for the
 // authenticated tenant that matches the job and target passed in.
 // Job and Target must be set to non empty strings.
-func (h *Client) QueryCheck(ctx context.Context, job string, target string) (*synthetic_monitoring.Check, error) {
+func (h *Client) QueryCheck(ctx context.Context, job string, target string) (*model.Check, error) {
 	if job == "" || target == "" {
 		return nil, fmt.Errorf("check query request: target and job must be set")
 	}
@@ -542,7 +542,7 @@ func (h *Client) QueryCheck(ctx context.Context, job string, target string) (*sy
 		return nil, fmt.Errorf("check query err: %w", err)
 	}
 
-	var result *synthetic_monitoring.Check
+	var result *model.Check
 
 	if err := ValidateResponse("check query request", resp, &result); err != nil {
 		return nil, err

--- a/smapi_test.go
+++ b/smapi_test.go
@@ -1053,13 +1053,16 @@ func TestAddCheck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	check := synthetic_monitoring.Check{}
+	check := synthetic_monitoring.Check{
+		FolderUid: "test-folder-uid",
+	}
 	newCheck, err := c.AddCheck(ctx, check)
 
 	require.NoError(t, err)
 	require.NotNil(t, newCheck)
 	require.Equal(t, testCheckID, newCheck.Id)
 	require.Equal(t, testTenant.id, newCheck.TenantId)
+	require.Equal(t, "test-folder-uid", newCheck.FolderUid)
 	require.Greater(t, newCheck.Created, float64(0))
 	require.Greater(t, newCheck.Modified, float64(0))
 	require.Empty(t, cmp.Diff(&check, newCheck, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
@@ -1073,10 +1076,11 @@ func TestGetCheck(t *testing.T) {
 	testCheckID := int64(42)
 	checks := []synthetic_monitoring.Check{
 		{
-			Id:       testCheckID,
-			TenantId: testTenantID,
-			Job:      "check-1",
-			Target:   "http://example.org/",
+			Id:        testCheckID,
+			TenantId:  testTenantID,
+			Job:       "check-1",
+			Target:    "http://example.org/",
+			FolderUid: "folder-abc",
 		},
 		{
 			Id:       testCheckID + 1,
@@ -1136,6 +1140,7 @@ func TestGetCheck(t *testing.T) {
 		actualCheck, err := c.GetCheck(ctx, testCheckID)
 		require.NoError(t, err)
 		require.NotNil(t, actualCheck)
+		require.Equal(t, "folder-abc", actualCheck.FolderUid)
 		found := false
 		for _, check := range checks {
 			check := check
@@ -1200,6 +1205,7 @@ func TestUpdateCheck(t *testing.T) {
 		Job:              "job",
 		BasicMetricsOnly: true,
 		Enabled:          true,
+		FolderUid:        "updated-folder",
 	}
 	newCheck, err := c.UpdateCheck(ctx, check)
 
@@ -1207,6 +1213,7 @@ func TestUpdateCheck(t *testing.T) {
 	require.NotNil(t, newCheck)
 	require.Equal(t, testCheckID, newCheck.Id)
 	require.Equal(t, testTenant.id, newCheck.TenantId)
+	require.Equal(t, "updated-folder", newCheck.FolderUid)
 	require.Greater(t, newCheck.Created, float64(0))
 	require.Greater(t, newCheck.Modified, float64(0))
 	require.Empty(t, cmp.Diff(&check, newCheck, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
@@ -1258,8 +1265,9 @@ func TestListChecks(t *testing.T) {
 	testTenantID := testTenant.id
 	checks := []synthetic_monitoring.Check{
 		{
-			Id:       42,
-			TenantId: testTenantID,
+			Id:        42,
+			TenantId:  testTenantID,
+			FolderUid: "folder-1",
 		},
 		{
 			Id:       43,
@@ -1301,8 +1309,9 @@ func TestListChecksWithAlerts(t *testing.T) {
 	checksWithAlerts := []model.CheckWithAlerts{
 		{
 			Check: synthetic_monitoring.Check{
-				Id:       42,
-				TenantId: testTenantID,
+				Id:        42,
+				TenantId:  testTenantID,
+				FolderUid: "folder-alerts",
 			},
 			Alerts: []model.CheckAlertWithStatus{
 				{
@@ -1356,10 +1365,11 @@ func TestQueryChecks(t *testing.T) {
 	testTenantId := testTenant.id
 	checks := []synthetic_monitoring.Check{
 		{
-			Id:       42,
-			TenantId: testTenantId,
-			Job:      "testing",
-			Target:   "icanhazip.com",
+			Id:        42,
+			TenantId:  testTenantId,
+			Job:       "testing",
+			Target:    "icanhazip.com",
+			FolderUid: "query-folder",
 		},
 		{
 			Id:       84,

--- a/smapi_test.go
+++ b/smapi_test.go
@@ -1032,7 +1032,7 @@ func TestAddCheck(t *testing.T) {
 	url, mux, cleanup := newTestServer(t)
 	defer cleanup()
 	mux.Handle("/api/v1/check/add", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req synthetic_monitoring.Check
+		var req model.Check
 		tenantID, err := readPostRequest(orgs, w, r, &req, testTenantID)
 		if err != nil {
 			return
@@ -1053,7 +1053,7 @@ func TestAddCheck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	check := synthetic_monitoring.Check{
+	check := model.Check{
 		FolderUid: "test-folder-uid",
 	}
 	newCheck, err := c.AddCheck(ctx, check)
@@ -1065,7 +1065,7 @@ func TestAddCheck(t *testing.T) {
 	require.Equal(t, "test-folder-uid", newCheck.FolderUid)
 	require.Greater(t, newCheck.Created, float64(0))
 	require.Greater(t, newCheck.Modified, float64(0))
-	require.Empty(t, cmp.Diff(&check, newCheck, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
+	require.Empty(t, cmp.Diff(&check.Check, &newCheck.Check, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
 		"AddCheck mismatch (-want +got)")
 }
 
@@ -1074,19 +1074,23 @@ func TestGetCheck(t *testing.T) {
 	testTenant := orgs.findTenantByOrg(1000)
 	testTenantID := testTenant.id
 	testCheckID := int64(42)
-	checks := []synthetic_monitoring.Check{
+	checks := []model.Check{
 		{
-			Id:        testCheckID,
-			TenantId:  testTenantID,
-			Job:       "check-1",
-			Target:    "http://example.org/",
+			Check: synthetic_monitoring.Check{
+				Id:       testCheckID,
+				TenantId: testTenantID,
+				Job:      "check-1",
+				Target:   "http://example.org/",
+			},
 			FolderUid: "folder-abc",
 		},
 		{
-			Id:       testCheckID + 1,
-			TenantId: testTenantID + 1,
-			Job:      "check-2",
-			Target:   "http://example.org/",
+			Check: synthetic_monitoring.Check{
+				Id:       testCheckID + 1,
+				TenantId: testTenantID + 1,
+				Job:      "check-2",
+				Target:   "http://example.org/",
+			},
 		},
 	}
 
@@ -1164,7 +1168,7 @@ func TestUpdateCheck(t *testing.T) {
 	url, mux, cleanup := newTestServer(t)
 	defer cleanup()
 	mux.Handle("/api/v1/check/update", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req synthetic_monitoring.Check
+		var req model.Check
 		tenantID, err := readPostRequest(orgs, w, r, &req, testTenantID)
 		if err != nil {
 			return
@@ -1195,17 +1199,19 @@ func TestUpdateCheck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	check := synthetic_monitoring.Check{
-		Id:               testCheckID,
-		TenantId:         testTenantID,
-		Frequency:        1000,
-		Timeout:          500,
-		Offset:           1,
-		Target:           "target",
-		Job:              "job",
-		BasicMetricsOnly: true,
-		Enabled:          true,
-		FolderUid:        "updated-folder",
+	check := model.Check{
+		Check: synthetic_monitoring.Check{
+			Id:               testCheckID,
+			TenantId:         testTenantID,
+			Frequency:        1000,
+			Timeout:          500,
+			Offset:           1,
+			Target:           "target",
+			Job:              "job",
+			BasicMetricsOnly: true,
+			Enabled:          true,
+		},
+		FolderUid: "updated-folder",
 	}
 	newCheck, err := c.UpdateCheck(ctx, check)
 
@@ -1216,8 +1222,8 @@ func TestUpdateCheck(t *testing.T) {
 	require.Equal(t, "updated-folder", newCheck.FolderUid)
 	require.Greater(t, newCheck.Created, float64(0))
 	require.Greater(t, newCheck.Modified, float64(0))
-	require.Empty(t, cmp.Diff(&check, newCheck, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
-		"AddCheck mismatch (-want +got)")
+	require.Empty(t, cmp.Diff(&check.Check, &newCheck.Check, ignoreIDField(), ignoreTenantIDField(), ignoreTimeFields()),
+		"UpdateCheck mismatch (-want +got)")
 }
 
 func TestDeleteCheck(t *testing.T) {
@@ -1263,15 +1269,19 @@ func TestListChecks(t *testing.T) {
 	orgs := orgs()
 	testTenant := orgs.findTenantByOrg(1000)
 	testTenantID := testTenant.id
-	checks := []synthetic_monitoring.Check{
+	checks := []model.Check{
 		{
-			Id:        42,
-			TenantId:  testTenantID,
+			Check: synthetic_monitoring.Check{
+				Id:       42,
+				TenantId: testTenantID,
+			},
 			FolderUid: "folder-1",
 		},
 		{
-			Id:       43,
-			TenantId: testTenantID,
+			Check: synthetic_monitoring.Check{
+				Id:       43,
+				TenantId: testTenantID,
+			},
 		},
 	}
 
@@ -1308,9 +1318,11 @@ func TestListChecksWithAlerts(t *testing.T) {
 	testTenantID := testTenant.id
 	checksWithAlerts := []model.CheckWithAlerts{
 		{
-			Check: synthetic_monitoring.Check{
-				Id:        42,
-				TenantId:  testTenantID,
+			Check: model.Check{
+				Check: synthetic_monitoring.Check{
+					Id:       42,
+					TenantId: testTenantID,
+				},
 				FolderUid: "folder-alerts",
 			},
 			Alerts: []model.CheckAlertWithStatus{
@@ -1363,29 +1375,32 @@ func TestQueryChecks(t *testing.T) {
 	orgs := orgs()
 	testTenant := orgs.findTenantByOrg(1000)
 	testTenantId := testTenant.id
-	checks := []synthetic_monitoring.Check{
+	checks := []model.Check{
 		{
-			Id:        42,
-			TenantId:  testTenantId,
-			Job:       "testing",
-			Target:    "icanhazip.com",
+			Check: synthetic_monitoring.Check{
+				Id:       42,
+				TenantId: testTenantId,
+				Job:      "testing",
+				Target:   "icanhazip.com",
+			},
 			FolderUid: "query-folder",
 		},
 		{
-			Id:       84,
-			TenantId: testTenantId,
-			Job:      "not-testing",
-			Target:   "nocanhazip.com",
+			Check: synthetic_monitoring.Check{
+				Id:       84,
+				TenantId: testTenantId,
+				Job:      "not-testing",
+				Target:   "nocanhazip.com",
+			},
 		},
 	}
 	url, mux, cleanup := newTestServer(t)
 	defer cleanup()
 	mux.Handle("/api/v1/check/query", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var resp *synthetic_monitoring.Check
+		var resp *model.Check
 		fmt.Println(r.URL.RawQuery)
 		job := r.URL.Query().Get("job")
 		target := r.URL.Query().Get("target")
-		// Emulate searching for a check
 		for _, check := range checks {
 			if check.Job == job && check.Target == target {
 				resp = &check


### PR DESCRIPTION
## Add `folderUid` support to checks

Part of https://github.com/grafana/synthetic-monitoring/issues/589

Adds support for the `folderUid` field on checks, allowing checks to be associated with a specific Grafana folder.

### Why

The SM API now returns and accepts a `folderUid` field on checks. This field is API-only, it is intentionally not part of the `protobuf` definition to avoid propagating it to probes.

### What changed

- **`model.Check`** — New wrapper type that embeds `synthetic_monitoring.Check` and adds `FolderUid`. This is the same pattern `CheckWithAlerts` already used for extending the proto type with API-only fields.
- **Tests** — Updated check tests to verify `folderUid` round-trips correctly through add, get, update, list, list-with-alerts, and query.

Check client methods now use `model.Check` instead of `synthetic_monitoring.Check`.