### PR TITLE
fix: Clean up dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,31 @@
 
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # Disable updates.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # Disable updates.
   - package-ecosystem: "gomod"
     directory: "/"
     labels:
       - "dependencies"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0 # Disable updates.
+  - package-ecosystem: "npm"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # Disable updates.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,8 @@
     "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
     "github>grafana/sm-renovate//presets/go.json5",
     "github>grafana/sm-renovate//presets/grafana-build-tools.json5"
+  ],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/automerge"
   ]
 }

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -1,0 +1,15 @@
+$schema: https://docs.renovatebot.com/renovate-schema.json
+
+extends:
+  - github>grafana/grafana-renovate-config//presets/base
+  - github>grafana/grafana-renovate-config//presets/docker
+  - github>grafana/grafana-renovate-config//presets/github-actions
+  - github>grafana/grafana-renovate-config//presets/shared-workflows
+  - github>grafana/sm-renovate//presets/grafana.json5
+  - github>grafana/sm-renovate//presets/synthetic-monitoring.json5
+  - github>grafana/sm-renovate//presets/go.json5
+  - github>grafana/sm-renovate//presets/grafana-build-tools.json5
+
+ignorePresets:
+  # TODO(mem): review this preset to decide if we want to enable it.
+  - github>grafana/grafana-renovate-config//presets/automerge

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -16,13 +16,20 @@ jobs:
       # Needed for logging into vault.
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-amd64-small
     timeout-minutes: 5
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Check drift
+        run: |
+          ./scripts/generate-renovate-config
+
+          ./scripts/check-renovate-config "$GITHUB_STEP_SUMMARY"
+
       - name: Validate Renovate Config
         uses: grafana/shared-workflows/actions/validate-renovate-config@726f1a912f45b4807774b76a6d40cbd3fb7a12c0 # validate-renovate-config/v0.1.2
         with:

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ publish-packages: package ## Publish Debian and RPM packages to the repository.
 	
 ##@ Helpers
 
+include scripts/make/620_generate_policy_bot_config.mk
+include scripts/make/630_generate_renovate_config.mk
+
 .PHONY: clean
 clean: ## Clean up intermediate build artifacts.
 	$(S) echo "Cleaning intermediate build artifacts..."

--- a/scripts/check-renovate-config
+++ b/scripts/check-renovate-config
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+input=.github/renovate.yaml
+output=.github/renovate.json
+
+summary_output=${1:-/dev/stdout}
+
+toplevel=$(git rev-parse --show-toplevel)
+cd "$toplevel"
+
+if ! git diff --exit-code "${output}" > /dev/null ; then
+	cat <<-EOT
+		::error file=$output,title=Out of date::$output is out of date with respect to $input. Run "make generate-renovate-config" to fix this.
+	EOT
+
+	cat <<-EOT >> "${summary_output}"
+		### Renovate configuration drift :bangbang:
+
+		\`$output\` is out of sync with respect to \`$input\`.
+
+		:bulb: Run \`make generate-renovate-config\` to update it.
+	EOT
+
+	exit 1
+fi
+
+exit 0

--- a/scripts/generate-renovate-config
+++ b/scripts/generate-renovate-config
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+input=.github/renovate.yaml
+output=.github/renovate.json
+
+toplevel=$(git rev-parse --show-toplevel)
+cd "$toplevel"
+
+if ! test -e "${input}" ; then
+	echo "W: ${input} does not exist. Stop." >&2
+	exit 0
+fi
+
+exec yq --output-format json . < "${input}" > "${output}"

--- a/scripts/make/630_generate_renovate_config.mk
+++ b/scripts/make/630_generate_renovate_config.mk
@@ -1,0 +1,5 @@
+.PHONY: generate-renovate-config
+generate-renovate-config: ## Generate renovate config.
+	$(S) echo 'Generating renovate configuration...'
+	$(V) $(ROOTDIR)/scripts/generate-renovate-config
+	$(S) echo 'Done.'


### PR DESCRIPTION
Add a dependabot configuration file that disables dependabot for all reasonable updates.

Clean up and rework the renovate configuration management bits. Most notable, dump .github/renovate.json5. JSON5 tooling is lacking, so it's a hassle to try to work with it. Instead, convert the existing file to YAML and add tooling to generate a JSON file out of that. Extend the renovate validation workflow so that it handles the drift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dependency-management configuration and CI validation; main risk is Renovate config drift tooling or runner changes causing workflow failures.
> 
> **Overview**
> Disables Dependabot updates by adding daily checks for `docker`, `github-actions`, `gomod`, and `npm` with `open-pull-requests-limit: 0`.
> 
> Moves Renovate to a YAML source-of-truth (`.github/renovate.yaml`) and generates `.github/renovate.json` from it, explicitly ignoring the upstream automerge preset.
> 
> Updates the Renovate validation workflow to run on `ubuntu-amd64-small` and to fail PRs when the generated JSON is out of sync (via new `scripts/generate-renovate-config`, `scripts/check-renovate-config`, and `make generate-renovate-config`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7a85bf44e1064b52c3dac4b725be55ceb3fa91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->